### PR TITLE
Test deploy pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,13 +62,13 @@ jobs:
           path: playwright-report/
           retention-days: 30
 
-      - name: upload build artifacts
-        uses: actions/upload-artifact@v4
-        with: 
-          name: built_file
-          path: dist/
-          retention-days: 1
-          overwrite: true
+      # - name: upload build artifacts
+      #   uses: actions/upload-artifact@v4
+      #   with: 
+      #     name: built_file
+      #     path: dist/
+      #     retention-days: 1
+      #     overwrite: true
 
   deployment:
     needs: [built_and_test]


### PR DESCRIPTION
use duplicate steps in built and test in the deploy step 
- name: Install dependencies
- name: Build

instead 
uses: actions/upload-artifact@v4
uses: actions/download-artifact@v4
upload/ download the dist folder >> result in zip file don't file a way how to extract.